### PR TITLE
Ansible Automation: Creating `bluetooth` role for handling Bluetooth config and services 📶

### DIFF
--- a/config/roles/bluetooth/README.md
+++ b/config/roles/bluetooth/README.md
@@ -1,32 +1,21 @@
-Role Name
-=========
+# Role Name
 
 This role is capable of handling audio coming from user device trough Bluetooth. 📶
 
-Requirements
-------------
+## Requirements
 
+## Role Variables
 
-Role Variables
---------------
-
-
-Dependencies
-------------
+## Dependencies
 
 None.
 
-Example Playbook
-----------------
+## Example Playbook
 
-
-
-License
--------
+## License
 
 BSD
 
-Author Information
-------------------
+## Author Information
 
 Ivo Karaneshev

--- a/config/roles/bluetooth/defaults/main.yml
+++ b/config/roles/bluetooth/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for bluetooth
+bluetooth_config: /etc/bluetooth/main.conf

--- a/config/roles/bluetooth/defaults/main.yml
+++ b/config/roles/bluetooth/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 # defaults file for bluetooth
-bt_speaker_service_dir: ~/...

--- a/config/roles/bluetooth/files/bluetooth-discoverable.service
+++ b/config/roles/bluetooth/files/bluetooth-discoverable.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Make Bluetooth discoverable on boot
+After=bluetooth.target
+
+[Service]
+ExecStart=/bin/bash -c "/usr/bin/bluetoothctl discoverable on && /usr/bin/bt-agent -c NoInputNoOutput"
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target

--- a/config/roles/bluetooth/meta/main.yml
+++ b/config/roles/bluetooth/meta/main.yml
@@ -1,7 +1,6 @@
 galaxy_info:
-  author: your name
-  description: your role description
-  company: your company (optional)
+  author: Ivo Karaneshev
+  description: This role is capable of handling audio coming from user device trough Bluetooth. 📶
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -14,14 +13,15 @@ galaxy_info:
   # - GPL-3.0-only
   # - Apache-2.0
   # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
+  license: BSD-3-Clause
 
   min_ansible_version: 2.1
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
 
-  galaxy_tags: []
+  galaxy_tags:
+    []
     # List tags for your role here, one per line. A tag is a keyword that describes
     # and categorizes the role. Users find roles by searching for tags. Be sure to
     # remove the '[]' above, if you add tags to this list.
@@ -29,6 +29,7 @@ galaxy_info:
     # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
     #       Maximum 20 tags per role.
 
-dependencies: []
+dependencies:
+  []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.

--- a/config/roles/bluetooth/tasks/main.yml
+++ b/config/roles/bluetooth/tasks/main.yml
@@ -1,2 +1,12 @@
 ---
-# tasks file for bluetooth
+- name: Set default Bluetooth settings to act as speaker
+  ansible.builtin.shell: >
+    sed -i \
+      -e 's/#AutoEnable.*/AutoEnable = true/' \
+      -e 's/#JustWorksRepairing.*/JustWorksRepairing = always/' \
+      -e 's/#FastConnectable.*/FastConnectable = true/' \
+      -e 's/#AlwaysPairable.*/AlwaysPairable = true/' \
+      -e 's/#DiscoverableTimeout.*/DiscoverableTimeout = 0/' \
+      -e 's/#PairableTimeout.*/PairableTimeout = 0/' \
+      {{ bluetooth_config }}
+

--- a/config/roles/bluetooth/tasks/main.yml
+++ b/config/roles/bluetooth/tasks/main.yml
@@ -10,3 +10,13 @@
       -e 's/#PairableTimeout.*/PairableTimeout = 0/' \
       {{ bluetooth_config }}
 
+- name: Register Bluetooth discovery service
+  ansible.builtin.copy:
+    src: files/bluetooth-discoverable.service
+    dest: /etc/systemd/system/bluetooth-discoverable.service
+    mode: "644"
+
+- name: Enable Bluetooth discovery service on boot
+  ansible.builtin.systemd_service:
+    name: bluetooth-discoverable
+    enabled: true

--- a/config/roles/setup/defaults/main.yml
+++ b/config/roles/setup/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 # defaults file for roles/setup
 apt_preferences_dir: /etc/apt/preferences.d/
-bluetooth_config: /etc/bluetooth/main.conf


### PR DESCRIPTION
## Changes made ✨:
- [x] Tweaking Bluetooth configuration in `/etc/bluetooth/main.conf` to make Pi act as Bluetooth speaker
```ini
AutoEnable = true
JustWorksRepairing = always
FastConnectable = true
AlwaysPairable = true
DiscoverableTimeout = 0
PairableTimeout = 0
```
- [x] Create a `bluetooth-discoverable.service` to make it **discoverable** and **pairable** on boot 
- [x] set the default agent to be `NoInputNoOutput` (i.e. without paring codes) through `bt-agent` (yeah is it needed to that way, don't know why but it works 🤔)