### PR TITLE
Fix: forgot to add crucial file for `setup` role 🙈

### DIFF
--- a/config/roles/setup/files/ffmpeg.pref
+++ b/config/roles/setup/files/ffmpeg.pref
@@ -1,0 +1,3 @@
+Package: ffmpeg libavcodec-dev libavcodec59 libavdevice59 libavfilter8 libavformat-dev libavformat59 libavutil-dev libavutil57 libpostproc56 libswresample-dev libswresample4 libswscale-dev libswscale6
+Pin: origin deb.debian.org
+Pin-Priority: 1001


### PR DESCRIPTION
The preferences file for downloading `ffmpeg` and it's deps (that `liquidsoap` requires) from **Debian** repositories instead of **Raspberry Pi** ones