### PR TITLE
Ansible Automation: Creating `wi-fi` role to ahandle everything related to Wi-Fi streaming 📡

### DIFF
--- a/config/roles/wi-fi/README.md
+++ b/config/roles/wi-fi/README.md
@@ -1,0 +1,19 @@
+# Role Name
+
+Configuration that aims to redirect incoming bluetooth stream to Wi-Fi radio 📡
+
+## Requirements
+
+## Role Variables
+
+## Dependencies
+
+## Example Playbook
+
+## License
+
+BSD
+
+## Author Information
+
+Ivo Karaneshev

--- a/config/roles/wi-fi/defaults/main.yml
+++ b/config/roles/wi-fi/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for config/roles/wi-fi
+icecast_config_file: /etc/icecast2/icecast.xml

--- a/config/roles/wi-fi/defaults/main.yml
+++ b/config/roles/wi-fi/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for config/roles/wi-fi

--- a/config/roles/wi-fi/handlers/main.yml
+++ b/config/roles/wi-fi/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for config/roles/wi-fi

--- a/config/roles/wi-fi/meta/main.yml
+++ b/config/roles/wi-fi/meta/main.yml
@@ -1,0 +1,35 @@
+galaxy_info:
+  author: Ivo Karaneshev
+  description: Configuration that aims to redirect incoming bluetooth stream to Wi-Fi radio 📡
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: BSD-3-Clause
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  galaxy_tags:
+    []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies:
+  []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/config/roles/wi-fi/tasks/icecast.yml
+++ b/config/roles/wi-fi/tasks/icecast.yml
@@ -1,0 +1,19 @@
+---
+- name: Configure authentication for Icecast
+  ansible.builtin.replace:
+    path: "{{ icecast_config_file }}"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  loop:
+    - {
+        regexp: "<source-password>.*</source-password>",
+        replace: "<source-password>{{ user_password }}</source-password>",
+      }
+    - {
+        regexp: "<relay-password>.*</relay-password>",
+        replace: "<relay-password>{{ user_password }}</relay-password>",
+      }
+    - {
+        regexp: "<admin-password>.*</admin-password>",
+        replace: "<admin-password>{{ root_password }}</admin-password>",
+      }

--- a/config/roles/wi-fi/tasks/icecast.yml
+++ b/config/roles/wi-fi/tasks/icecast.yml
@@ -17,3 +17,8 @@
         regexp: "<admin-password>.*</admin-password>",
         replace: "<admin-password>{{ root_password }}</admin-password>",
       }
+
+- name: Start the Icecast service
+  ansible.builtin.systemd_service:
+    name: icecast2
+    enabled: true

--- a/config/roles/wi-fi/tasks/liquidsoap.yml
+++ b/config/roles/wi-fi/tasks/liquidsoap.yml
@@ -1,0 +1,6 @@
+---
+- name: Create Liquidsoap configuration folder for default user
+  ansible.builtin.file:
+    path: "/home/{{ user_name }}/liquidsoap"
+    state: directory
+    owner: "{{ user_name }}"

--- a/config/roles/wi-fi/tasks/liquidsoap.yml
+++ b/config/roles/wi-fi/tasks/liquidsoap.yml
@@ -21,3 +21,8 @@
   ansible.builtin.template:
     src: templates/liquidsoap.service.j2
     dest: /etc/systemd/system/liquidsoap.service
+
+- name: Enable Liquidsoap bridge service at boot
+  ansible.builtin.systemd_service:
+    name: liquidsoap
+    enabled: true

--- a/config/roles/wi-fi/tasks/liquidsoap.yml
+++ b/config/roles/wi-fi/tasks/liquidsoap.yml
@@ -16,3 +16,8 @@
     src: templates/password.liq.j2
     dest: "/home/{{ user_name }}/liquidsoap/password.liq"
     owner: "{{ user_name }}"
+
+- name: Register Liquidsoap bridge service
+  ansible.builtin.template:
+    src: templates/liquidsoap.service.j2
+    dest: /etc/systemd/system/liquidsoap.service

--- a/config/roles/wi-fi/tasks/liquidsoap.yml
+++ b/config/roles/wi-fi/tasks/liquidsoap.yml
@@ -4,3 +4,15 @@
     path: "/home/{{ user_name }}/liquidsoap"
     state: directory
     owner: "{{ user_name }}"
+
+- name: Add the Liquidsoap stream source file
+  ansible.builtin.template:
+    src: templates/bridge.liq.j2
+    dest: "/home/{{ user_name }}/liquidsoap/bridge.liq"
+    owner: "{{ user_name }}"
+
+- name: Add credentials to be used by Liquidsoap
+  ansible.builtin.template:
+    src: templates/password.liq.j2
+    dest: "/home/{{ user_name }}/liquidsoap/password.liq"
+    owner: "{{ user_name }}"

--- a/config/roles/wi-fi/tasks/main.yml
+++ b/config/roles/wi-fi/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Icecast server related configuration
+  ansible.builtin.import_tasks:
+    file: icecast.yml

--- a/config/roles/wi-fi/tasks/main.yml
+++ b/config/roles/wi-fi/tasks/main.yml
@@ -2,3 +2,7 @@
 - name: Icecast server related configuration
   ansible.builtin.import_tasks:
     file: icecast.yml
+
+- name: Liquidsoap related configuration
+  ansible.builtin.import_tasks:
+    file: liquidsoap.yml

--- a/config/roles/wi-fi/templates/bridge.liq.j2
+++ b/config/roles/wi-fi/templates/bridge.liq.j2
@@ -1,0 +1,17 @@
+%include "password.liq"
+
+set("log.file",true)
+set("log.file.path", "/home/{{ user_name }}/liquidsoap/bridge.log")
+
+# Define the source as a single track, looped indefinitely
+bluetooth_audio = input.pulseaudio()
+
+# Stream to Icecast
+output.icecast(
+  %opus,
+  host="localhost",
+  port=8000,
+  password=source_password,
+  mount="stream.opus",
+  bluetooth_audio
+)

--- a/config/roles/wi-fi/templates/liquidsoap.service.j2
+++ b/config/roles/wi-fi/templates/liquidsoap.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Liquidsoap Streamer Service
+After=network.target bluetooth-discoverable.service
+
+[Service]
+Environment="PULSE_SERVER=unix:/run/user/1000/pulse/native"
+#Environment="PIPEWIRE_RUNTIME_DIR=/run/user/1000/pipewire"
+Type=forking
+PIDFile=/home/{{ user_name }}/liquidsoap/bridge.pid
+ExecStart=/usr/bin/liquidsoap --debug /home/{{ user_name }}/liquidsoap/bridge.liq
+Restart=always
+User={{ user_name }}
+
+[Install]
+WantedBy=multi-user.target

--- a/config/roles/wi-fi/templates/password.liq.j2
+++ b/config/roles/wi-fi/templates/password.liq.j2
@@ -1,0 +1,1 @@
+source_password = "{{ user_password }}"

--- a/config/roles/wi-fi/tests/inventory
+++ b/config/roles/wi-fi/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/config/roles/wi-fi/tests/test.yml
+++ b/config/roles/wi-fi/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - config/roles/wi-fi

--- a/config/roles/wi-fi/vars/main.yml
+++ b/config/roles/wi-fi/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for config/roles/wi-fi


### PR DESCRIPTION
## Changes made ✨:
- [x] `icecast2` - configuration and starting the service for streaming and providing URL to which peripheral nodes will "attach" to listen
- [x] `liquidsoap` 
    - writing a script that redirects incoming Bluetooth stream to Icecast
    - writing and enabling a service to run the script on boot