### PR TITLE
Fix: Docker related settings 🐳

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN rm -rf /var/lib/apt/lists/*
 ENV PATH=/root/.local/bin:$PATH
 
 RUN pipx install --include-deps ansible-core
+RUN pipx inject ansible-core passlib
 
 RUN mkdir -p /etc/ansible/ && \
     echo "[local]\nlocalhost" > /etc/ansible/hosts

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-docker build -t justivo/ansible .
-
-docker compose up -d
+docker build -t justivo/ansible . \
+    && docker compose up -d


### PR DESCRIPTION
## Changes made ✨:
- [x] Run `docker compose up -d` if `docker build` has no errors
- [x] Add `passlib` python library which is used by **Ansible** for `password_hash` filter 