### PR TITLE
Fix: Resolve the problem between Bluetooth, Pipewire and Liquidsoap 🐱‍💻

### DIFF
--- a/config/roles/bluetooth/files/bluetooth-discoverable.service
+++ b/config/roles/bluetooth/files/bluetooth-discoverable.service
@@ -1,10 +1,13 @@
 [Unit]
 Description=Make Bluetooth discoverable on boot
-After=bluetooth.target
+After=bluetooth.target pipewire.service
 
 [Service]
 ExecStart=/bin/bash -c "/usr/bin/bluetoothctl discoverable on && /usr/bin/bt-agent -c NoInputNoOutput"
 KillSignal=SIGINT
+Restart=always
+RestartOnFailure=yes
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/config/roles/setup/defaults/main.yml
+++ b/config/roles/setup/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 # defaults file for roles/setup
 apt_preferences_dir: /etc/apt/preferences.d/
+wireplumber_global_config_path: /etc/wireplumber/
+wireplumber_bluetooth_config: "{{ wireplumber_global_config_path }}/bluetooth.lua.d"

--- a/config/roles/setup/defaults/main.yml
+++ b/config/roles/setup/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for roles/setup
-apt_preferences_dir: /etc/apt/preferences.d/
+apt_preferences_dir: /etc/apt/preferences.d
 
-wireplumber_global_config_path: /etc/wireplumber/
+wireplumber_global_config_path: /etc/wireplumber
 wireplumber_bluetooth_config: "{{ wireplumber_global_config_path }}/bluetooth.lua.d"
 
 user_home_dir: "/home/{{ user_name }}"

--- a/config/roles/setup/defaults/main.yml
+++ b/config/roles/setup/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 # defaults file for roles/setup
 apt_preferences_dir: /etc/apt/preferences.d/
+
 wireplumber_global_config_path: /etc/wireplumber/
 wireplumber_bluetooth_config: "{{ wireplumber_global_config_path }}/bluetooth.lua.d"
+
+user_home_dir: "/home/{{ user_name }}"
+user_services_dir: "{{ user_home_dir }}/.config/systemd/user"

--- a/config/roles/setup/files/50-bluez-config.lua
+++ b/config/roles/setup/files/50-bluez-config.lua
@@ -1,0 +1,3 @@
+bluez_monitor.properties = {
+    ["with-logind"] = false,
+  }

--- a/config/roles/setup/files/91-remove-restore-props.lua
+++ b/config/roles/setup/files/91-remove-restore-props.lua
@@ -1,0 +1,4 @@
+table.insert(stream_defaults.properties, {
+    -- do not restore the last stream properties in order to set volume everytime on boot
+    ["restore-props"] = false,
+  })

--- a/config/roles/setup/files/volume-up.service
+++ b/config/roles/setup/files/volume-up.service
@@ -1,0 +1,12 @@
+[Unit]
+Description="Set PipeWire initial volume level to 80%"
+Requires=wireplumber.service pipewire.service pipewire-pulse.service
+After=sound.target wireplumber.service pipewire.service pipewire-pulse.service
+
+[Service]
+Type=simple
+ExecStartPre=/bin/sleep 5
+ExecStart=/usr/bin/wpctl set-volume @DEFAULT_AUDIO_SINK@ 80%
+
+[Install]
+WantedBy=default.target

--- a/config/roles/setup/tasks/main.yml
+++ b/config/roles/setup/tasks/main.yml
@@ -14,3 +14,7 @@
 - name: User related settings
   ansible.builtin.import_tasks:
     file: users.yml
+
+- name: Sound related settings
+  ansible.builtin.import_tasks:
+    file: sound.yml

--- a/config/roles/setup/tasks/packages.yml
+++ b/config/roles/setup/tasks/packages.yml
@@ -11,6 +11,7 @@
       - pipewire
       - wireplumber
       - pipewire-pulse
+      - pipewire-alsa
       - libspa-0.2-bluetooth
     default_release: "bullseye-backports"
     state: present

--- a/config/roles/setup/tasks/sound.yml
+++ b/config/roles/setup/tasks/sound.yml
@@ -11,13 +11,31 @@
       - pipewire
       - bluetooth
 
-- name: Create global config folder for wireplumber to ovveride stock /etc/ssh/sshd_config
+- name: Create global config folder for WirePlumber to override stock config
   ansible.builtin.file:
-    path: "{{ wireplumber_bluetooth_config }}"
+    path: "{{ item }}"
     state: directory
+  loop:
+    - "{{ wireplumber_bluetooth_config }}"
+    - "{{ wireplumber_global_config_path }}/main.lua.d"
 
-- name: Disable wireplumber's "logind-monitor" to make it run system-wide
+- name: Disable WirePlumber's "logind-monitor" to make it run system-wide
   ansible.builtin.copy:
     src: files/50-bluez-config.lua
     dest: "{{ wireplumber_bluetooth_config }}/50-bluez-config.lua"
     mode: "644"
+
+- name: Disable WirePlumber's "restore-session" key to set volume automatically on boot
+  ansible.builtin.copy:
+    src: files/91-remove-restore-props.lua
+    dest: "{{ wireplumber_global_config_path }}/main.lua.d/91-remove-restore-props.lua"
+    mode: "644"
+
+- name: Register the user service to set volume everytime on boot
+  ansible.builtin.copy:
+    src: files/volume-up.service
+    dest: "{{ user_services_dir }}/volume-up.service"
+    owner: "{{ user_name }}"
+
+- name: Enable the volume up service to run on boot
+  ansible.builtin.command: "systemctl --user -M {{ user_name }}@ enable volume-up.service"

--- a/config/roles/setup/tasks/sound.yml
+++ b/config/roles/setup/tasks/sound.yml
@@ -1,0 +1,23 @@
+---
+- name: "Enable lingering for `{{ user_name }}`"
+  ansible.builtin.command: "loginctl enable-linger {{ user_name }}"
+
+- name: "Adding `{{ user_name }}` to sound related user groups"
+  ansible.builtin.user:
+    user: "{{ user_name }}"
+    append: true
+    groups:
+      - audio
+      - pipewire
+      - bluetooth
+
+- name: Create global config folder for wireplumber to ovveride stock /etc/ssh/sshd_config
+  ansible.builtin.file:
+    path: "{{ wireplumber_bluetooth_config }}"
+    state: directory
+
+- name: Disable wireplumber's "logind-monitor" to make it run system-wide
+  ansible.builtin.copy:
+    src: files/50-bluez-config.lua
+    dest: "{{ wireplumber_bluetooth_config }}/50-bluez-config.lua"
+    mode: "644"

--- a/config/roles/setup/tasks/users.yml
+++ b/config/roles/setup/tasks/users.yml
@@ -22,9 +22,13 @@
   ansible.builtin.user:
     name: "{{ user_name }}"
     password: "{{ user_password | password_hash }}"
-    groups:
-      - sudo
     append: true
+
+- name: "Add default user to all default groups"
+  ansible.builtin.replace:
+    path: /etc/group
+    regexp: ":pi"
+    replace: ":thesis"
 
 - name: Set root password
   ansible.builtin.user:

--- a/config/roles/setup/tasks/users.yml
+++ b/config/roles/setup/tasks/users.yml
@@ -24,6 +24,12 @@
     password: "{{ user_password | password_hash }}"
     append: true
 
+- name: "Create folder for user-defined systemd units"
+  ansible.builtin.file:
+    path: "{{ user_home_dir }}/.config/systemd/user"
+    owner: "{{ user_name }}"
+    state: directory
+
 - name: "Add default user to all default groups"
   ansible.builtin.replace:
     path: /etc/group


### PR DESCRIPTION
## Changes made ✨:
- [x] start `bluetooth-discoverable.service` **_after_** `pipewire.service` have been started and make it able to restart itself if it fails
- [x] run all Pipewire-related services (`pipewire.service`, `pipewire.socket`, `wireplumber.service`, `pipewire-pulse.service`, and so on) without needing a user to be logged, i.e. making them system-wide running services by making default user `linger`ing
- [x] add the default user to the groups that `pi` user belongs to
- [x] create a user-defined systems service to set the volume to 80% everytime on boot 