### PR TITLE
Fix: Change `wpa_supplicants` network cnofiguration with Network Manager way 🌐

### DIFF
--- a/config/roles/setup/tasks/prefs.yml
+++ b/config/roles/setup/tasks/prefs.yml
@@ -6,16 +6,8 @@
     line: 'XKBLAYOUT="us"'
 
 - name: Automatically connect to SSID on boot
-  ansible.builtin.blockinfile:
-    path: /etc/wpa_supplicant/wpa_supplicant.conf
-    append_newline: true
-    prepend_newline: true
-    block: |
-      country=BG
+  ansible.builtin.template:
+    src: templates/ssid.nmconnection.j2
+    dest: "/etc/NetworkManager/system-connections/{{ wifi_ssid }}.nmconnection"
+    mode: "600"
 
-      network={
-        scan_ssid=1
-        ssid="{{ wifi_ssid }}"
-        psk="{{ wifi_password }}"
-        key_mgmt=WPA-PSK
-      }

--- a/config/roles/setup/templates/ssid.nmconnection.j2
+++ b/config/roles/setup/templates/ssid.nmconnection.j2
@@ -1,0 +1,30 @@
+[connection]
+id={{ wifi_ssid }}
+uuid={{ wifi_ssid | to_uuid }}
+type=wifi
+interface-name=wlan0
+
+[wifi]
+mode=infrastructure
+ssid={{ wifi_ssid }}
+
+[wifi-security]
+auth-alg=open
+key-mgmt=wpa-psk
+psk={{ wifi_password }}
+
+[ipv4]
+method=auto
+
+[ipv6]
+addr-gen-mode=default
+method=auto
+
+[main]
+plugins=ifupdown,keyfile
+
+[ifupdown]
+managed=false
+
+[device]
+wifi.scan-rand-mac-address=no


### PR DESCRIPTION
## Changes made ✨:
According to raspberrypi/bookworm-feedback#72 Debian Bookworm have changed how networking is configured so the way with editing the `/etc/wpa_supplicant/wpa_supplicant.conf` doesn't work (tested).

- [x] So took another approach using **_Network Manager_** by creating `{{ wfi_ssid }}.nmconnection` file with generated UUID